### PR TITLE
Implement user profiles and token tracking

### DIFF
--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -4,6 +4,9 @@ import { OpenaiModule } from 'src/openai/openai.module';
 import { VoiceModule } from 'src/voice/voice.module';
 import { TelegrafModule } from 'nestjs-telegraf';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserProfile } from '../user/entities/user-profile.entity';
+import { UserTokens } from '../user/entities/user-tokens.entity';
 
 // telegram.module.ts
 @Module({
@@ -16,6 +19,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
         telegram: { apiRoot: 'https://api.telegram.org', timeout: 120_000 },
       }),
     }),
+    TypeOrmModule.forFeature([UserProfile, UserTokens]),
     OpenaiModule,
     VoiceModule,
   ],

--- a/src/user/entities/user-profile.entity.ts
+++ b/src/user/entities/user-profile.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, OneToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { UserTokens } from './user-tokens.entity';
+
+// Сущность профиля пользователя в Telegram
+
+@Entity()
+export class UserProfile {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  telegramId: number;
+
+  @Column({ nullable: true })
+  firstName?: string;
+
+  @Column({ nullable: true })
+  username?: string;
+
+  @Column({ type: 'timestamptz' })
+  firstVisitAt: Date;
+
+  @Column({ type: 'timestamptz' })
+  lastMessageAt: Date;
+
+  @Column({ nullable: true })
+  userTokensId: number;
+
+  @OneToOne(() => UserTokens, (tokens) => tokens.user, { cascade: true })
+  @JoinColumn({ name: 'userTokensId' })
+  tokens: UserTokens;
+}

--- a/src/user/entities/user-tokens.entity.ts
+++ b/src/user/entities/user-tokens.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { UserProfile } from './user-profile.entity';
+
+// Баланс токенов пользователя
+
+@Entity()
+export class UserTokens {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ default: 100 })
+  tokens: number;
+
+  @Column()
+  userId: number;
+
+  @OneToOne(() => UserProfile, (profile) => profile.tokens, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserProfile;
+}


### PR DESCRIPTION
## Summary
- create `UserProfile` and `UserTokens` entities to store Telegram user info and token balance
- integrate repositories into Telegram module
- track user presence and tokens in `TelegramService`
- add Russian comments explaining new entities

## Testing
- `npm test` *(fails: jest not found)*