### PR TITLE
Fix telegramId storage as bigint

### DIFF
--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -42,14 +42,16 @@ export class TelegramService {
   private async ensureUser(ctx: Context): Promise<UserProfile | null> {
     const from = ctx.message.from;
     let profile = await this.profileRepo.findOne({
-      where: { telegramId: from.id },
+      // Сравниваем строковый telegramId
+      where: { telegramId: String(from.id) },
       relations: ['tokens'],
     });
 
     const now = new Date();
     if (!profile) {
       profile = this.profileRepo.create({
-        telegramId: from.id,
+        // Сохраняем telegramId как строку
+        telegramId: String(from.id),
         firstName: from.first_name,
         username: from.username,
         firstVisitAt: now,

--- a/src/user/entities/user-profile.entity.ts
+++ b/src/user/entities/user-profile.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, OneToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToOne,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { UserTokens } from './user-tokens.entity';
 
 // Сущность профиля пользователя в Telegram
@@ -8,8 +14,10 @@ export class UserProfile {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ unique: true })
-  telegramId: number;
+  // Храним ID пользователя как bigint,
+  // потому что Telegram выдаёт значения больше 2^31
+  @Column({ unique: true, type: 'bigint' })
+  telegramId: string;
 
   @Column({ nullable: true })
   firstName?: string;


### PR DESCRIPTION
## Summary
- store telegramId as bigint in the user profile
- handle telegramId as string when creating/searching profiles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*