### PR TITLE
Добавлена миграция для обязательного telegramId

### DIFF
--- a/src/migrations/1697049000000-UserProfileTelegramIdNotNull.ts
+++ b/src/migrations/1697049000000-UserProfileTelegramIdNotNull.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Миграция добавляет ограничение NOT NULL для поля telegramId
+export class UserProfileTelegramIdNotNull1697049000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Удаляем или обновляем записи без telegramId. Проще всего удалить
+    await queryRunner.query(`DELETE FROM "user_profile" WHERE "telegramId" IS NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "user_profile" ALTER COLUMN "telegramId" SET NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Возвращаем возможность хранить NULL
+    await queryRunner.query(
+      `ALTER TABLE "user_profile" ALTER COLUMN "telegramId" DROP NOT NULL`
+    );
+  }
+}

--- a/src/user/entities/user-profile.entity.ts
+++ b/src/user/entities/user-profile.entity.ts
@@ -16,7 +16,8 @@ export class UserProfile {
 
   // Храним ID пользователя как bigint,
   // потому что Telegram выдаёт значения больше 2^31
-  @Column({ unique: true, type: 'bigint' })
+  // поле telegramId обязательно к заполнению
+  @Column({ unique: true, type: 'bigint', nullable: false })
   telegramId: string;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## Изменения
- миграция для добавления ограничения `NOT NULL` на `telegramId` в таблице `user_profile`
- колонка `telegramId` в сущности `UserProfile` теперь явно отмечена как `nullable: false`

## Тесты
- `npm test` (падает: `jest: not found`)
