### PR TITLE
Inject config into voice service

### DIFF
--- a/src/voice/voice.module.ts
+++ b/src/voice/voice.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { VoiceService } from './voice.service/voice.service';
 
 @Module({
+  imports: [ConfigModule], // подключаем ConfigModule, если не был подключён
   providers: [VoiceService],
   exports: [VoiceService], // ← обязательно экспортируем!
 })

--- a/src/voice/voice.service/voice.service.ts
+++ b/src/voice/voice.service/voice.service.ts
@@ -29,13 +29,18 @@ ffmpeg.setFfmpegPath(ffmpegPath);
 @Injectable()
 export class VoiceService {
   private readonly logger = new Logger(VoiceService.name);
-  private readonly configService = new ConfigService();
-  private readonly client = new OpenAI({
-    apiKey: this.configService.get<string>('OPENAI_API_KEY_PRO'),
-    baseURL: 'https://chat.neurolabtg.ru/v1',
-  });
+  private readonly client: OpenAI;
 
-  constructor(@InjectBot() private readonly bot: Telegraf) {}
+  constructor(
+    @InjectBot() private readonly bot: Telegraf,
+    private readonly configService: ConfigService,
+  ) {
+    // Инициализируем клиента OpenAI, используя переданный ConfigService
+    this.client = new OpenAI({
+      apiKey: this.configService.get<string>('OPENAI_API_KEY_PRO'),
+      baseURL: 'https://chat.neurolabtg.ru/v1',
+    });
+  }
 
   /** 1️⃣  OGG → текст (Whisper) */
   async voiceToText(voice: TgVoice): Promise<string> {


### PR DESCRIPTION
## Summary
- inject ConfigService into `VoiceService` constructor and initialize OpenAI client with it
- import ConfigModule in `VoiceModule`

## Testing
- `npm test` *(fails: jest not found)*