### PR TITLE
Add QR invite link

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "telegraf": "^4.16.3",
-    "typeorm": "^0.3.22"
+    "typeorm": "^0.3.22",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",


### PR DESCRIPTION
## Summary
- add `qrcode` dependency
- show invite link as text and QR code in profile
- parse payload for `/start` manually when deprecated `startPayload` is empty

## Testing
- `npm test` *(fails: jest not found)*