### PR TITLE
fix start command flow

### DIFF
--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -168,9 +168,12 @@ export class TelegramService {
   private registerHandlers() {
     this.bot.on('text', async (ctx, next) => {
       try {
+        const q = ctx.message.text?.trim();
+        if (q?.startsWith('/start')) {
+          return next();
+        }
         const user = await this.ensureUser(ctx);
         if (!user) return;
-        const q = ctx.message.text?.trim();
         if (!q) return;
 
         // пропускаем другие команды, кроме '/image', чтобы они обработались далее


### PR DESCRIPTION
## Summary
- allow `/start` command to reach its handler before `ensureUser`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*