### PR TITLE
Fix dev config loading

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TelegramModule } from './telegram/telegram.module';
 import { OpenaiModule } from './openai/openai.module';
@@ -15,29 +15,35 @@ import { VoiceModule } from './voice/voice.module';
       expandVariables: true,
     }),
     // Подключение к локальной базе данных проекта
-    TypeOrmModule.forRoot({
-      type: 'postgres',
-      host: process.env.DATABASE_HOST,
-      port: Number(process.env.DATABASE_PORT),
-      username: process.env.DB_USER,
-      password: process.env.DB_PASS,
-      database: process.env.DB_NAME,
-      autoLoadEntities: true,
-      synchronize: true,
-      // migrations: [__dirname + '/migrations/*{.ts,.js}'],
-      // migrationsRun: true,
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        type: 'postgres',
+        host: cfg.get<string>('DATABASE_HOST'),
+        port: Number(cfg.get<string>('DATABASE_PORT')),
+        username: cfg.get<string>('DB_USER'),
+        password: cfg.get<string>('DB_PASS'),
+        database: cfg.get<string>('DB_NAME'),
+        autoLoadEntities: true,
+        synchronize: true,
+        // migrations: [__dirname + '/migrations/*{.ts,.js}'],
+        // migrationsRun: true,
+      }),
     }),
     // Подключение к основной базе данных проекта
-    TypeOrmModule.forRoot({
+    TypeOrmModule.forRootAsync({
       name: 'mainDb',
-      type: 'postgres',
-      host: process.env.MAIN_DB_HOST,
-      port: Number(process.env.MAIN_DB_PORT),
-      username: process.env.MAIN_DB_USER,
-      password: process.env.MAIN_DB_PASS,
-      database: process.env.MAIN_DB_NAME,
-      entities: [__dirname + '/**/*.entity{.ts,.js}'],
-      synchronize: false,
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        type: 'postgres',
+        host: cfg.get<string>('MAIN_DB_HOST'),
+        port: Number(cfg.get<string>('MAIN_DB_PORT')),
+        username: cfg.get<string>('MAIN_DB_USER'),
+        password: cfg.get<string>('MAIN_DB_PASS'),
+        database: cfg.get<string>('MAIN_DB_NAME'),
+        entities: [__dirname + '/**/*.entity{.ts,.js}'],
+        synchronize: false,
+      }),
     }),
     TelegramModule,
     OpenaiModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { config } from 'dotenv';
+
+// Load environment variables before Nest application bootstrap
+config({
+  path: process.env.NODE_ENV === 'development' ? 'development.env' : '.env',
+  override: true,
+});
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -12,7 +12,6 @@ import { MainUser } from '../external/entities/main-user.entity';
 // telegram.module.ts
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }), // .env грузится глобально
     TelegrafModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (cfg: ConfigService) => ({


### PR DESCRIPTION
## Summary
- load configuration from one place in AppModule
- remove second ConfigModule.forRoot call in TelegramModule
- load env vars before bootstrap and use ConfigService for DB options

## Testing
- `npm test` *(fails: DEFAULT_BOT_NAME provider missing, ConfigService not in RootTestModule, OpenAiService module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685263f82168832c819c0e496b544a9f