### PR TITLE
Update telegram subscription links

### DIFF
--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -73,13 +73,18 @@ export class TelegramService {
       if (!profile.tokens.plan) {
         await ctx.reply(
           'На Вашем балансе недостаточно токенов для генерации.\nДля продолжения работы с ботом приобретите подписку по одному из планов:\nLITE 2000 рублей - 1000 токенов,\nPRO 5000 рублей - 3500 токенов',
-          Markup.inlineKeyboard([Markup.button.callback('LITE', 'subscribe_LITE'), Markup.button.callback('PRO', 'subscribe_PRO')]),
+          Markup.inlineKeyboard([
+            Markup.button.url('LITE', 'https://t.me/test_NLab_bot?start=itemByID_22'),
+            Markup.button.url('PRO', 'https://t.me/test_NLab_bot?start=itemByID_23'),
+          ]),
         );
       } else {
         const price = profile.tokens.plan === 'LITE' ? 400 : 200;
         await ctx.reply(
           `На Вашем балансе недостаточно токенов для генерации.\nДля продолжения работы с ботом пополните баланс:\n${price} рублей - 1000 токенов`,
-          Markup.inlineKeyboard([Markup.button.callback('пополнить', 'topup')]),
+          Markup.inlineKeyboard([
+            Markup.button.url('пополнить', 'https://t.me/test_NLab_bot?start=itemByID_24'),
+          ]),
         );
       }
       return false;
@@ -194,7 +199,10 @@ export class TelegramService {
       }
       await ctx.reply(
         'Срок действия подписки истёк. Для продолжения работы с ботом приобретите подписку по одному из планов:\nLITE 2000 рублей - 1000 токенов,\nPRO 5000 рублей - 3500 токенов',
-        Markup.inlineKeyboard([Markup.button.callback('LITE', 'subscribe_LITE'), Markup.button.callback('PRO', 'subscribe_PRO')]),
+        Markup.inlineKeyboard([
+          Markup.button.url('LITE', 'https://t.me/test_NLab_bot?start=itemByID_22'),
+          Markup.button.url('PRO', 'https://t.me/test_NLab_bot?start=itemByID_23'),
+        ]),
       );
       return null;
     }
@@ -355,7 +363,10 @@ export class TelegramService {
         }
         await ctx.reply(
           'Срок действия подписки истёк. Для продолжения работы с ботом приобретите подписку по одному из планов:\nLITE 2000 рублей - 1000 токенов,\nPRO 5000 рублей - 3500 токенов',
-          Markup.inlineKeyboard([Markup.button.callback('LITE', 'subscribe_LITE'), Markup.button.callback('PRO', 'subscribe_PRO')]),
+          Markup.inlineKeyboard([
+            Markup.button.url('LITE', 'https://t.me/test_NLab_bot?start=itemByID_22'),
+            Markup.button.url('PRO', 'https://t.me/test_NLab_bot?start=itemByID_23'),
+          ]),
         );
         return;
       }


### PR DESCRIPTION
## Summary
- update inline buttons with direct URLs for subscription and topup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867bff7d860832c8c06d71356aafa0f