### PR TITLE
Rename Lite plan to Plus with new payment button

### DIFF
--- a/src/user/entities/user-tokens.entity.ts
+++ b/src/user/entities/user-tokens.entity.ts
@@ -11,13 +11,13 @@ export class UserTokens {
   @Column({ default: 100 })
   tokens: number;
 
-  // Тарифный план пользователя: LITE или PRO
+  // Тарифный план пользователя: PLUS или PRO
   @Column({ nullable: true })
-  plan?: 'LITE' | 'PRO';
+  plan?: 'PLUS' | 'PRO';
 
-  // Ожидаемый тип платежа: LITE, PRO или TOPUP
+  // Ожидаемый тип платежа: PLUS, PRO или TOPUP
   @Column({ nullable: true })
-  pendingPayment?: 'LITE' | 'PRO' | 'TOPUP';
+  pendingPayment?: 'PLUS' | 'PRO' | 'TOPUP';
 
   // Дата начала оплаченного периода
   @Column({ type: 'timestamptz', nullable: true })


### PR DESCRIPTION
## Summary
- rename `LITE` plan to `PLUS` everywhere
- add "оплачено" button when showing subscription or top-up options

## Testing
- `npm test` *(fails: cannot resolve module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68775c448c60832cbed8091d3b54c1a4