### PR TITLE
Handle promindAction in paid order check

### DIFF
--- a/src/external/entities/order-item.entity.ts
+++ b/src/external/entities/order-item.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+// Item of an order from main project
+@Entity({ name: 'order_items' })
+export class MainOrderItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  orderId: number;
+
+  @Column({ nullable: true })
+  promindAction?: string;
+}

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -11,6 +11,7 @@ import { TokenTransaction } from '../user/entities/token-transaction.entity';
 import { OrderIncome } from '../user/entities/order-income.entity';
 import { MainUser } from '../external/entities/main-user.entity';
 import { MainOrder } from '../external/entities/order.entity';
+import { MainOrderItem } from '../external/entities/order-item.entity';
 
 // telegram.module.ts
 @Module({
@@ -24,7 +25,7 @@ import { MainOrder } from '../external/entities/order.entity';
     }),
     // Регистрируем репозитории для локальной и основной БД
     TypeOrmModule.forFeature([UserProfile, UserTokens, TokenTransaction, OrderIncome]),
-    TypeOrmModule.forFeature([MainUser, MainOrder], 'mainDb'),
+    TypeOrmModule.forFeature([MainUser, MainOrder, MainOrderItem], 'mainDb'),
     OpenaiModule,
     VoiceModule,
   ],

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -13,6 +13,7 @@ import { TokenTransaction } from 'src/user/entities/token-transaction.entity';
 import { OrderIncome } from 'src/user/entities/order-income.entity';
 import { MainUser } from 'src/external/entities/main-user.entity';
 import { MainOrder } from 'src/external/entities/order.entity';
+import { MainOrderItem } from 'src/external/entities/order-item.entity';
 
 @Injectable()
 export class TelegramService {
@@ -42,6 +43,8 @@ export class TelegramService {
     private readonly mainUserRepo: Repository<MainUser>,
     @InjectRepository(MainOrder, 'mainDb')
     private readonly orderRepo: Repository<MainOrder>,
+    @InjectRepository(MainOrderItem, 'mainDb')
+    private readonly orderItemRepo: Repository<MainOrderItem>,
     @InjectRepository(OrderIncome)
     private readonly incomeRepo: Repository<OrderIncome>,
   ) {
@@ -614,19 +617,43 @@ export class TelegramService {
         });
         if (exists) continue;
 
-        const income = await this.incomeRepo.save(this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }));
+        const items = await this.orderItemRepo.find({ where: { orderId: order.id } });
 
-        let add = 1000;
-        if (order.totalAmount === 2000) {
-          add = 1000;
-          profile.tokens.plan = 'PLUS';
-        } else if (order.totalAmount === 5000) {
-          add = 3500;
-          profile.tokens.plan = 'PRO';
+        let add = 0;
+        let upgrade: 'PLUS' | 'PRO' | null = null;
+        let subscription = false;
+        for (const item of items) {
+          switch (item.promindAction) {
+            case 'plus':
+              add += 1000;
+              upgrade = 'PLUS';
+              subscription = true;
+              break;
+            case 'pro':
+              add += 3500;
+              upgrade = 'PRO';
+              subscription = true;
+              break;
+            case 'tokens':
+              add += 1000;
+              break;
+            default:
+              break;
+          }
+        }
+
+        if (add === 0) continue;
+
+        const income = await this.incomeRepo.save(
+          this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }),
+        );
+
+        if (upgrade) {
+          profile.tokens.plan = upgrade;
         }
 
         const now = new Date();
-        if (order.totalAmount === 2000 || order.totalAmount === 5000) {
+        if (subscription) {
           const until = new Date(now);
           until.setDate(until.getDate() + 30);
           profile.tokens.dateSubscription = now;


### PR DESCRIPTION
## Summary
- add entity for order items from the main DB
- register new repository in the Telegram module
- check `promindAction` on paid orders when processing payments

## Testing
- `npm test` *(fails: Cannot resolve dependencies)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fa5cf4654832c822734a268192b4e