### PR TITLE
Update payment processing with promindAction

### DIFF
--- a/src/constants/promind-action.enum.ts
+++ b/src/constants/promind-action.enum.ts
@@ -1,0 +1,5 @@
+export enum PromindAction {
+  PLUS = 'plus',
+  PRO = 'pro',
+  TOKENS = 'tokens',
+}

--- a/src/external/entities/order.entity.ts
+++ b/src/external/entities/order.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { PromindAction } from '../../constants/promind-action.enum';
 
 // Order record from main project
 @Entity({ name: 'orders' })
@@ -23,5 +24,5 @@ export class MainOrder {
 
   // Тип действия в Promind: plus, pro или tokens
   @Column({ name: 'promind_action', nullable: true })
-  promindAction?: 'plus' | 'pro' | 'tokens';
+  promindAction?: PromindAction;
 }

--- a/src/external/entities/order.entity.ts
+++ b/src/external/entities/order.entity.ts
@@ -20,4 +20,8 @@ export class MainOrder {
 
   @Column({ default: false })
   promind: boolean;
+
+  // Тип действия в Promind: plus, pro или tokens
+  @Column({ name: 'promind_action', nullable: true })
+  promindAction?: 'plus' | 'pro' | 'tokens';
 }

--- a/src/migrations/1751994656000-AddPromindActionToOrders.ts
+++ b/src/migrations/1751994656000-AddPromindActionToOrders.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Добавляет поле promind_action в таблицу orders
+export class AddPromindActionToOrders1751994656000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "orders" ADD "promind_action" varchar`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "orders" DROP COLUMN "promind_action"`);
+  }
+}

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -13,6 +13,7 @@ import { TokenTransaction } from 'src/user/entities/token-transaction.entity';
 import { OrderIncome } from 'src/user/entities/order-income.entity';
 import { MainUser } from 'src/external/entities/main-user.entity';
 import { MainOrder } from 'src/external/entities/order.entity';
+import { PromindAction } from 'src/constants/promind-action.enum';
 
 @Injectable()
 export class TelegramService {
@@ -533,7 +534,9 @@ export class TelegramService {
         totalAmount: plan === 'PLUS' ? 2000 : 5000,
         totalPoints: 1,
         userId: mainUser.id,
-        promindAction: plan === 'PLUS' ? 'plus' : 'pro',
+        promind: true,
+        promindAction:
+          plan === 'PLUS' ? PromindAction.PLUS : PromindAction.PRO,
       });
       await this.orderRepo.save(order);
 
@@ -618,18 +621,21 @@ export class TelegramService {
         const income = await this.incomeRepo.save(this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }));
 
         let add = 1000;
-        if (order.promindAction === 'plus') {
+        if (order.promindAction === PromindAction.PLUS) {
           add = 1000;
           profile.tokens.plan = 'PLUS';
-        } else if (order.promindAction === 'pro') {
+        } else if (order.promindAction === PromindAction.PRO) {
           add = 3500;
           profile.tokens.plan = 'PRO';
-        } else if (order.promindAction === 'tokens') {
+        } else if (order.promindAction === PromindAction.TOKENS) {
           add = 1000;
         }
 
         const now = new Date();
-        if (order.promindAction === 'plus' || order.promindAction === 'pro') {
+        if (
+          order.promindAction === PromindAction.PLUS ||
+          order.promindAction === PromindAction.PRO
+        ) {
           const until = new Date(now);
           until.setDate(until.getDate() + 30);
           profile.tokens.dateSubscription = now;

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -533,6 +533,7 @@ export class TelegramService {
         totalAmount: plan === 'PLUS' ? 2000 : 5000,
         totalPoints: 1,
         userId: mainUser.id,
+        promindAction: plan === 'PLUS' ? 'plus' : 'pro',
       });
       await this.orderRepo.save(order);
 
@@ -617,16 +618,18 @@ export class TelegramService {
         const income = await this.incomeRepo.save(this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }));
 
         let add = 1000;
-        if (order.totalAmount === 2000) {
+        if (order.promindAction === 'plus') {
           add = 1000;
           profile.tokens.plan = 'PLUS';
-        } else if (order.totalAmount === 5000) {
+        } else if (order.promindAction === 'pro') {
           add = 3500;
           profile.tokens.plan = 'PRO';
+        } else if (order.promindAction === 'tokens') {
+          add = 1000;
         }
 
         const now = new Date();
-        if (order.totalAmount === 2000 || order.totalAmount === 5000) {
+        if (order.promindAction === 'plus' || order.promindAction === 'pro') {
           const until = new Date(now);
           until.setDate(until.getDate() + 30);
           profile.tokens.dateSubscription = now;


### PR DESCRIPTION
## Summary
- extend orders with `promindAction`
- handle promindAction when creating paid orders
- use promindAction to credit tokens in the payment_done handler
- add migration for new promindAction column

## Testing
- `npm run test` *(fails: OpenaiService and VoiceService dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fb6230700832cbe9795f31bbbc612