### PR TITLE
Update order items handling

### DIFF
--- a/src/external/entities/order-item.entity.ts
+++ b/src/external/entities/order-item.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+// Item within an order from the main project
+@Entity({ name: 'orders_items' })
+export class MainOrderItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  orderId: number;
+
+  @Column({ nullable: true, name: 'promind_action' })
+  promindAction?: 'plus' | 'pro' | 'tokens';
+}

--- a/src/external/entities/order.entity.ts
+++ b/src/external/entities/order.entity.ts
@@ -20,4 +20,5 @@ export class MainOrder {
 
   @Column({ default: false })
   promind: boolean;
+
 }

--- a/src/openai/openai.service/openai.service.spec.ts
+++ b/src/openai/openai.service/openai.service.spec.ts
@@ -1,12 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { OpenAiService } from './openai.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('OpenaiService', () => {
   let provider: OpenAiService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OpenAiService],
+      providers: [
+        OpenAiService,
+        { provide: ConfigService, useValue: { get: () => 'test-key' } },
+      ],
     }).compile();
 
     provider = module.get<OpenAiService>(OpenAiService);

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -11,6 +11,7 @@ import { TokenTransaction } from '../user/entities/token-transaction.entity';
 import { OrderIncome } from '../user/entities/order-income.entity';
 import { MainUser } from '../external/entities/main-user.entity';
 import { MainOrder } from '../external/entities/order.entity';
+import { MainOrderItem } from '../external/entities/order-item.entity';
 
 // telegram.module.ts
 @Module({
@@ -24,7 +25,7 @@ import { MainOrder } from '../external/entities/order.entity';
     }),
     // Регистрируем репозитории для локальной и основной БД
     TypeOrmModule.forFeature([UserProfile, UserTokens, TokenTransaction, OrderIncome]),
-    TypeOrmModule.forFeature([MainUser, MainOrder], 'mainDb'),
+    TypeOrmModule.forFeature([MainUser, MainOrder, MainOrderItem], 'mainDb'),
     OpenaiModule,
     VoiceModule,
   ],

--- a/src/telegram/telegram.service/telegram.service.spec.ts
+++ b/src/telegram/telegram.service/telegram.service.spec.ts
@@ -1,12 +1,43 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TelegramService } from './telegram.service';
+import { getBotToken } from 'nestjs-telegraf';
+import { OpenAiService } from '../../openai/openai.service/openai.service';
+import { VoiceService } from '../../voice/voice.service/voice.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserProfile } from '../../user/entities/user-profile.entity';
+import { UserTokens } from '../../user/entities/user-tokens.entity';
+import { TokenTransaction } from '../../user/entities/token-transaction.entity';
+import { OrderIncome } from '../../user/entities/order-income.entity';
+import { MainUser } from '../../external/entities/main-user.entity';
+import { MainOrder } from '../../external/entities/order.entity';
+import { MainOrderItem } from '../../external/entities/order-item.entity';
+import { ConfigService } from '@nestjs/config';
 
 describe('TelegramService', () => {
   let provider: TelegramService;
 
   beforeEach(async () => {
+    jest
+      .spyOn(TelegramService.prototype as any, 'registerHandlers')
+      .mockImplementation(() => {});
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TelegramService],
+      providers: [
+        TelegramService,
+        {
+          provide: getBotToken(),
+          useValue: { on: jest.fn(), action: jest.fn(), catch: jest.fn(), telegram: {} },
+        },
+        { provide: OpenAiService, useValue: {} },
+        { provide: VoiceService, useValue: {} },
+        { provide: ConfigService, useValue: { get: () => '' } },
+        { provide: getRepositoryToken(UserProfile), useValue: {} },
+        { provide: getRepositoryToken(UserTokens), useValue: {} },
+        { provide: getRepositoryToken(TokenTransaction), useValue: {} },
+        { provide: getRepositoryToken(MainUser, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(MainOrder, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(MainOrderItem, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(OrderIncome), useValue: {} },
+      ],
     }).compile();
 
     provider = module.get<TelegramService>(TelegramService);

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -13,6 +13,7 @@ import { TokenTransaction } from 'src/user/entities/token-transaction.entity';
 import { OrderIncome } from 'src/user/entities/order-income.entity';
 import { MainUser } from 'src/external/entities/main-user.entity';
 import { MainOrder } from 'src/external/entities/order.entity';
+import { MainOrderItem } from 'src/external/entities/order-item.entity';
 
 @Injectable()
 export class TelegramService {
@@ -42,6 +43,8 @@ export class TelegramService {
     private readonly mainUserRepo: Repository<MainUser>,
     @InjectRepository(MainOrder, 'mainDb')
     private readonly orderRepo: Repository<MainOrder>,
+    @InjectRepository(MainOrderItem, 'mainDb')
+    private readonly orderItemRepo: Repository<MainOrderItem>,
     @InjectRepository(OrderIncome)
     private readonly incomeRepo: Repository<OrderIncome>,
   ) {
@@ -614,19 +617,33 @@ export class TelegramService {
         });
         if (exists) continue;
 
-        const income = await this.incomeRepo.save(this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }));
+        const income = await this.incomeRepo.save(
+          this.incomeRepo.create({ mainOrderId: order.id, userId: mainUser.id }),
+        );
+
+        const items = await this.orderItemRepo.find({ where: { orderId: order.id } });
+        let action: 'plus' | 'pro' | 'tokens' | null = null;
+        for (const item of items) {
+          if (item.promindAction) {
+            action = item.promindAction as 'plus' | 'pro' | 'tokens';
+            break;
+          }
+        }
+        if (!action) continue;
 
         let add = 1000;
-        if (order.totalAmount === 2000) {
+        if (action === 'plus') {
           add = 1000;
           profile.tokens.plan = 'PLUS';
-        } else if (order.totalAmount === 5000) {
+        } else if (action === 'pro') {
           add = 3500;
           profile.tokens.plan = 'PRO';
+        } else if (action === 'tokens') {
+          add = 1000;
         }
 
         const now = new Date();
-        if (order.totalAmount === 2000 || order.totalAmount === 5000) {
+        if (action === 'plus' || action === 'pro') {
           const until = new Date(now);
           until.setDate(until.getDate() + 30);
           profile.tokens.dateSubscription = now;

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -3,17 +3,17 @@ import { InjectBot } from 'nestjs-telegraf';
 import { Telegraf, Context, Markup } from 'telegraf';
 import * as QRCode from 'qrcode';
 import * as path from 'path';
-import { OpenAiService } from 'src/openai/openai.service/openai.service';
-import { VoiceService } from 'src/voice/voice.service/voice.service';
+import { OpenAiService } from '../../openai/openai.service/openai.service';
+import { VoiceService } from '../../voice/voice.service/voice.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UserProfile } from 'src/user/entities/user-profile.entity';
-import { UserTokens } from 'src/user/entities/user-tokens.entity';
-import { TokenTransaction } from 'src/user/entities/token-transaction.entity';
-import { OrderIncome } from 'src/user/entities/order-income.entity';
-import { MainUser } from 'src/external/entities/main-user.entity';
-import { MainOrder } from 'src/external/entities/order.entity';
-import { MainOrderItem } from 'src/external/entities/order-item.entity';
+import { UserProfile } from '../../user/entities/user-profile.entity';
+import { UserTokens } from '../../user/entities/user-tokens.entity';
+import { TokenTransaction } from '../../user/entities/token-transaction.entity';
+import { OrderIncome } from '../../user/entities/order-income.entity';
+import { MainUser } from '../../external/entities/main-user.entity';
+import { MainOrder } from '../../external/entities/order.entity';
+import { MainOrderItem } from '../../external/entities/order-item.entity';
 
 @Injectable()
 export class TelegramService {

--- a/src/voice/voice.service/voice.service.spec.ts
+++ b/src/voice/voice.service/voice.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { VoiceService } from './voice.service';
+import { getBotToken } from 'nestjs-telegraf';
+import { ConfigService } from '@nestjs/config';
 
 describe('VoiceService', () => {
   let provider: VoiceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VoiceService],
+      providers: [
+        VoiceService,
+        {
+          provide: getBotToken(),
+          useValue: { telegram: { getFileLink: jest.fn() } },
+        },
+        { provide: ConfigService, useValue: { get: () => 'key' } },
+      ],
     }).compile();
 
     provider = module.get<VoiceService>(VoiceService);


### PR DESCRIPTION
## Summary
- remove `promindAction` from order entity
- add new `MainOrderItem` entity
- read `promindAction` from order items during payment processing
- register new entity in Telegram module

## Testing
- `npm install`
- `npm test` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fcae58f70832cab58798e540ce95e