### PR TITLE
Compute tokens from order items

### DIFF
--- a/src/external/entities/item.entity.ts
+++ b/src/external/entities/item.entity.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'items' })
+export class Item {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: true })
+  promindAction: string;
+}

--- a/src/external/entities/order-item.entity.ts
+++ b/src/external/entities/order-item.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+// Item of an order from main project
+@Entity({ name: 'order_items' })
+export class MainOrderItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  orderId: number;
+
+  @Column({ nullable: true })
+  promindAction: string;
+}

--- a/src/external/entities/order-item.entity.ts
+++ b/src/external/entities/order-item.entity.ts
@@ -1,6 +1,6 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Item } from './item.entity';
 
-// Item of an order from main project
 @Entity({ name: 'order_items' })
 export class MainOrderItem {
   @PrimaryGeneratedColumn()
@@ -9,6 +9,10 @@ export class MainOrderItem {
   @Column()
   orderId: number;
 
-  @Column({ nullable: true })
-  promindAction: string;
+  @Column()
+  itemId: number;
+
+  @ManyToOne(() => Item)
+  @JoinColumn({ name: 'itemId' })
+  item: Item;
 }

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -11,6 +11,7 @@ import { TokenTransaction } from '../user/entities/token-transaction.entity';
 import { OrderIncome } from '../user/entities/order-income.entity';
 import { MainUser } from '../external/entities/main-user.entity';
 import { MainOrder } from '../external/entities/order.entity';
+import { MainOrderItem } from '../external/entities/order-item.entity';
 
 // telegram.module.ts
 @Module({
@@ -24,7 +25,7 @@ import { MainOrder } from '../external/entities/order.entity';
     }),
     // Регистрируем репозитории для локальной и основной БД
     TypeOrmModule.forFeature([UserProfile, UserTokens, TokenTransaction, OrderIncome]),
-    TypeOrmModule.forFeature([MainUser, MainOrder], 'mainDb'),
+    TypeOrmModule.forFeature([MainUser, MainOrder, MainOrderItem], 'mainDb'),
     OpenaiModule,
     VoiceModule,
   ],

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -12,6 +12,7 @@ import { OrderIncome } from '../user/entities/order-income.entity';
 import { MainUser } from '../external/entities/main-user.entity';
 import { MainOrder } from '../external/entities/order.entity';
 import { MainOrderItem } from '../external/entities/order-item.entity';
+import { Item } from '../external/entities/item.entity';
 
 // telegram.module.ts
 @Module({
@@ -25,7 +26,7 @@ import { MainOrderItem } from '../external/entities/order-item.entity';
     }),
     // Регистрируем репозитории для локальной и основной БД
     TypeOrmModule.forFeature([UserProfile, UserTokens, TokenTransaction, OrderIncome]),
-    TypeOrmModule.forFeature([MainUser, MainOrder, MainOrderItem], 'mainDb'),
+    TypeOrmModule.forFeature([MainUser, MainOrder, MainOrderItem, Item], 'mainDb'),
     OpenaiModule,
     VoiceModule,
   ],

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -617,7 +617,10 @@ export class TelegramService {
         });
         if (exists) continue;
 
-        const items = await this.orderItemRepo.find({ where: { orderId: order.id } });
+        const items = await this.orderItemRepo.find({
+          where: { orderId: order.id },
+          relations: ['item'],
+        });
         if (items.length === 0) continue;
 
         const income = await this.incomeRepo.save(
@@ -626,16 +629,17 @@ export class TelegramService {
 
         let add = 0;
         let isSubscription = false;
-        for (const item of items) {
-          if (item.promindAction === 'plus') {
+        for (const orderItem of items) {
+          const action = (orderItem.item?.promindAction || '').toLowerCase();
+          if (action === 'plus') {
             add += 1000;
             profile.tokens.plan = 'PLUS';
             isSubscription = true;
-          } else if (item.promindAction === 'pro') {
+          } else if (action === 'pro') {
             add += 3500;
             profile.tokens.plan = 'PRO';
             isSubscription = true;
-          } else if (item.promindAction === 'tokens') {
+          } else if (action === 'tokens') {
             add += 1000;
           }
         }


### PR DESCRIPTION
## Summary
- add `MainOrderItem` entity for access to `order_items`
- import `MainOrderItem` in `TelegramModule`
- inject `orderItemRepo` into `TelegramService`
- compute payment bonuses from `promindAction` of order items instead of order total amount

## Testing
- `npm test` *(fails: OpenaiService and VoiceService dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880cdc94934832cb43a9261d2ab0869