### PR TITLE
Add SessionService for session caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9372,6 +9372,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "node-fetch": "^2.7.0",
     "openai": "^4.96.2",
     "pg": "^8.15.6",
+    "qrcode": "^1.5.3",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "telegraf": "^4.16.3",
-    "typeorm": "^0.3.22",
-    "qrcode": "^1.5.3"
+    "typeorm": "^0.3.22"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/openai/openai.module.ts
+++ b/src/openai/openai.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { OpenAiService } from './openai.service/openai.service';
+import { SessionModule } from '../session/session.module';
 
 @Module({
+  imports: [SessionModule],
   providers: [OpenAiService],
   exports: [OpenAiService], // ← обязательно экспортируем!
 })

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserProfile } from '../user/entities/user-profile.entity';
+import { SessionService } from './session.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserProfile])],
+  providers: [SessionService],
+  exports: [SessionService],
+})
+export class SessionModule {}

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserProfile } from '../user/entities/user-profile.entity';
+
+@Injectable()
+export class SessionService {
+  private cache = new Map<number, string>();
+
+  constructor(
+    @InjectRepository(UserProfile)
+    private readonly profileRepo: Repository<UserProfile>,
+  ) {}
+
+  async getSessionId(userId: number): Promise<string | null> {
+    const cached = this.cache.get(userId);
+    if (cached) {
+      return cached;
+    }
+
+    const profile = await this.profileRepo.findOne({ where: { id: userId } });
+    if (profile?.sessionId) {
+      this.cache.set(userId, profile.sessionId);
+      return profile.sessionId;
+    }
+
+    return null;
+  }
+
+  async clearSession(userId: number): Promise<void> {
+    this.cache.delete(userId);
+    await this.profileRepo.update({ id: userId }, { sessionId: null });
+  }
+
+  async setSessionId(userId: number, sessionId: string): Promise<void> {
+    this.cache.set(userId, sessionId);
+    await this.profileRepo.update({ id: userId }, { sessionId });
+  }
+}

--- a/src/user/entities/user-profile.entity.ts
+++ b/src/user/entities/user-profile.entity.ts
@@ -41,6 +41,9 @@ export class UserProfile {
   @Column({ nullable: true })
   userTokensId: number;
 
+  @Column({ nullable: true })
+  sessionId?: string;
+
   // Дата начала оплаченного тарифа
   @Column({ type: 'timestamptz', nullable: true })
   dateSubscription?: Date;


### PR DESCRIPTION
## Summary
- install dependencies
- add optional session ID field to user profile
- use SessionService to fetch and persist session IDs
- return `null` from SessionService if a session ID isn't stored

## Testing
- `npm run build`
- `npm test` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688142ec9098832c82d19cb6e75516dc