### PR TITLE
Add main bot link from env

### DIFF
--- a/example.env
+++ b/example.env
@@ -2,6 +2,9 @@
 # Параметры подключения к локальной базе данных
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
+DB_USER=db_user
+DB_PASS=db_password
+DB_NAME=bot_db
 
 # Подключение к основной БД
 MAIN_DB_HOST=localhost
@@ -9,6 +12,9 @@ MAIN_DB_PORT=5432
 MAIN_DB_USER=main_user
 MAIN_DB_PASS=main_password
 MAIN_DB_NAME=main_db
+
+# Ссылка на основного бота компании
+MAIN_BOT_LINK=https://t.me/personal_assistent_NeuroLab_bot
 
 # Токен вашего бота Telegram
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token


### PR DESCRIPTION
## Summary
- получать ссылку на основной бот из переменной окружения
- обновить пример `.env`
- генерировать реферальные ссылки через указанную ссылку

## Testing
- `npm run test` *(ошибка: jest не найден)*
- `npm run build` *(ошибка: nest не найден)*

------
https://chatgpt.com/codex/tasks/task_e_68824348a980832683c3f9a3c520afe9