### PR TITLE
Fix photo variation to handle PNG and size

### DIFF
--- a/src/openai/openai.service/openai.service.spec.ts
+++ b/src/openai/openai.service/openai.service.spec.ts
@@ -1,12 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { OpenAiService } from './openai.service';
+import { ConfigService } from '@nestjs/config';
+import { SessionService } from '../../session/session.service';
 
 describe('OpenaiService', () => {
   let provider: OpenAiService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OpenAiService],
+      providers: [
+        OpenAiService,
+        { provide: ConfigService, useValue: { get: jest.fn(() => 'test') } },
+        {
+          provide: SessionService,
+          useValue: {
+            getSessionId: jest.fn(),
+            setSessionId: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     provider = module.get<OpenAiService>(OpenAiService);

--- a/src/openai/openai.service/openai.service.ts
+++ b/src/openai/openai.service/openai.service.ts
@@ -41,10 +41,10 @@ export class OpenAiService {
             '-compression_level',
             '9',
           ])
-          .toFormat('png')
-          .save(outPath)
+          .output(outPath)
           .on('end', () => resolve())
-          .on('error', (err: Error) => reject(err));
+          .on('error', (err: Error) => reject(err))
+          .run();
       });
       result = await fs.readFile(outPath);
       if (result.length <= 4 * 1024 * 1024) break;

--- a/src/openai/openai.service/openai.service.ts
+++ b/src/openai/openai.service/openai.service.ts
@@ -212,7 +212,7 @@ export class OpenAiService {
     try {
       // изображение конвертируется в PNG и уменьшатся до < 4 МБ
       const prepared = await this.prepareImage(image);
-      const file = await toFile(prepared, 'image.png');
+      const file = await toFile(prepared, 'image.png', { type: 'image/png' });
       // Используем ту же модель, что и при обычной генерации,
       // передавая текст пользователя в качестве промта
       const { data } = await this.openAi.images.edit({
@@ -277,7 +277,7 @@ export class OpenAiService {
 
       // загружаем файл для ассистента
       const prepared = await this.prepareImage(image);
-      const fileObj = await toFile(prepared, 'image.png');
+      const fileObj = await toFile(prepared, 'image.png', { type: 'image/png' });
       const file = await this.openAi.files.create({
         file: fileObj,
         purpose: 'assistants',

--- a/src/telegram/telegram.service/telegram.service.spec.ts
+++ b/src/telegram/telegram.service/telegram.service.spec.ts
@@ -1,12 +1,48 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TelegramService } from './telegram.service';
+import { ConfigService } from '@nestjs/config';
+import { getBotToken } from 'nestjs-telegraf';
+import { DEFAULT_BOT_NAME } from 'nestjs-telegraf/dist/telegraf.constants';
+import { OpenAiService } from '../../openai/openai.service/openai.service';
+import { VoiceService } from '../../voice/voice.service/voice.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserProfile } from '../../user/entities/user-profile.entity';
+import { UserTokens } from '../../user/entities/user-tokens.entity';
+import { TokenTransaction } from '../../user/entities/token-transaction.entity';
+import { OrderIncome } from '../../user/entities/order-income.entity';
+import { MainUser } from '../../external/entities/main-user.entity';
+import { MainOrder } from '../../external/entities/order.entity';
+import { MainOrderItem } from '../../external/entities/order-item.entity';
 
 describe('TelegramService', () => {
   let provider: TelegramService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TelegramService],
+      providers: [
+        TelegramService,
+        {
+          provide: getBotToken(DEFAULT_BOT_NAME),
+          useValue: {
+            on: jest.fn(),
+            command: jest.fn(),
+            hears: jest.fn(),
+            start: jest.fn(),
+            action: jest.fn(),
+            catch: jest.fn(),
+          },
+        },
+        { provide: OpenAiService, useValue: {} },
+        { provide: VoiceService, useValue: {} },
+        { provide: ConfigService, useValue: { get: jest.fn(() => '') } },
+        { provide: getRepositoryToken(UserProfile), useValue: {} },
+        { provide: getRepositoryToken(UserTokens), useValue: {} },
+        { provide: getRepositoryToken(TokenTransaction), useValue: {} },
+        { provide: getRepositoryToken(MainUser, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(MainOrder, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(MainOrderItem, 'mainDb'), useValue: {} },
+        { provide: getRepositoryToken(OrderIncome), useValue: {} },
+      ],
     }).compile();
 
     provider = module.get<TelegramService>(TelegramService);

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -379,7 +379,8 @@ export class TelegramService {
         if (caption.startsWith('/image')) {
           if (!(await this.chargeTokens(ctx, user, this.COST_IMAGE))) return;
           const drawMsg = await this.sendAnimation(ctx, 'drawing_a.mp4', 'РИСУЮ ...');
-          const image = await this.openai.generateImageFromPhoto(buffer);
+          const prompt = caption.replace('/image', '').trim();
+          const image = await this.openai.generateImageFromPhoto(buffer, prompt);
           await ctx.telegram.deleteMessage(ctx.chat.id, drawMsg.message_id);
           if (image) {
             await this.sendPhoto(ctx, image);

--- a/src/telegram/telegram.service/telegram.service.ts
+++ b/src/telegram/telegram.service/telegram.service.ts
@@ -4,17 +4,17 @@ import { Telegraf, Context, Markup } from 'telegraf';
 import * as QRCode from 'qrcode';
 import * as path from 'path';
 import fetch from 'node-fetch';
-import { OpenAiService } from 'src/openai/openai.service/openai.service';
-import { VoiceService } from 'src/voice/voice.service/voice.service';
+import { OpenAiService } from '../../openai/openai.service/openai.service';
+import { VoiceService } from '../../voice/voice.service/voice.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UserProfile } from 'src/user/entities/user-profile.entity';
-import { UserTokens } from 'src/user/entities/user-tokens.entity';
-import { TokenTransaction } from 'src/user/entities/token-transaction.entity';
-import { OrderIncome } from 'src/user/entities/order-income.entity';
-import { MainUser } from 'src/external/entities/main-user.entity';
-import { MainOrder } from 'src/external/entities/order.entity';
-import { MainOrderItem } from 'src/external/entities/order-item.entity';
+import { UserProfile } from '../../user/entities/user-profile.entity';
+import { UserTokens } from '../../user/entities/user-tokens.entity';
+import { TokenTransaction } from '../../user/entities/token-transaction.entity';
+import { OrderIncome } from '../../user/entities/order-income.entity';
+import { MainUser } from '../../external/entities/main-user.entity';
+import { MainOrder } from '../../external/entities/order.entity';
+import { MainOrderItem } from '../../external/entities/order-item.entity';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()

--- a/src/voice/voice.service/voice.service.spec.ts
+++ b/src/voice/voice.service/voice.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { VoiceService } from './voice.service';
+import { ConfigService } from '@nestjs/config';
+import { getBotToken } from 'nestjs-telegraf';
+import { DEFAULT_BOT_NAME } from 'nestjs-telegraf/dist/telegraf.constants';
 
 describe('VoiceService', () => {
   let provider: VoiceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VoiceService],
+      providers: [
+        VoiceService,
+        { provide: getBotToken(DEFAULT_BOT_NAME), useValue: {} },
+        { provide: ConfigService, useValue: { get: jest.fn(() => '') } },
+      ],
     }).compile();
 
     provider = module.get<VoiceService>(VoiceService);


### PR DESCRIPTION
## Summary
- preprocess user images with ffmpeg before hitting OpenAI
- adjust TelegramService and tests to work with local imports and stubs
- stub dependencies in VoiceService and OpenAiService tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cfbf841388326bb39d066fa54130d